### PR TITLE
Added previous and next buttons for slider in home page

### DIFF
--- a/src/assets/styles/ImageSlider.css
+++ b/src/assets/styles/ImageSlider.css
@@ -14,4 +14,24 @@
     border-radius: 10px;
   }
 
+  /*Slider button styles*/
+.custom-arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  color: white;
+  font-size: 4rem;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.prev-arrow {
+  left: 10px; /* Position of the prev button */
+}
+
+.next-arrow {
+  right: 10px; /* Position of the next button */
+}
+
+
   

--- a/src/components/ImageSlider.js
+++ b/src/components/ImageSlider.js
@@ -55,6 +55,19 @@ const ImageWithCursorEffect = ({ imageSrc, altText }) => {
   );
 };
 
+// Custom arrow components for prev and next buttons
+const PrevArrow = ({ onClick }) => (
+  <div className="custom-arrow prev-arrow" onClick={onClick}>
+    &laquo;
+  </div>
+);
+
+const NextArrow = ({ onClick }) => (
+  <div className="custom-arrow next-arrow" onClick={onClick}>
+    &raquo;
+  </div>
+);
+
 const ImageSlider = () => {
   const settings = {
     dots: true,
@@ -64,6 +77,8 @@ const ImageSlider = () => {
     slidesToScroll: 1,
     autoplay: true,
     autoplaySpeed: 3000,
+    prevArrow: <PrevArrow />, // Adding custom prev arrow
+    nextArrow: <NextArrow />, // Adding custom next arrow
   };
 
   return (


### PR DESCRIPTION
I have added the previous and next buttons for slider in home page for the users to navigate between the slides.
Modified two files: ImageSlider.js and ImageSlider.css

Output:
![Capturedmfgkfg](https://github.com/user-attachments/assets/03797241-0bfe-46f2-8542-34fd916f05c2)

@samyakmaitre Kindly review at the earliest.
Note: I am a gssoc-ext and hacktoberfest contributor.